### PR TITLE
chore: clean PTDAMH imports

### DIFF
--- a/src/PTDAMH.py
+++ b/src/PTDAMH.py
@@ -25,7 +25,6 @@ This module expects your `Proposals.py` next to it. It does **not** modify
 from __future__ import annotations
 
 from dataclasses import dataclass
-from multiprocessing.util import info
 from typing import Callable, NamedTuple, Tuple, Sequence
 
 import jax
@@ -33,16 +32,9 @@ import jax.numpy as jnp
 from jax import lax, random, vmap
 import numpy as np
 from jax.scipy.linalg import solve_triangular
-from tqdm import tqdm
-from tqdm import trange
-
-
-import Proposals  # your file with proposal factories
-
 from tqdm import trange, tqdm
 
-
-import Proposals  # your file with proposal factories
+import Proposals  # your file with proposal factories  # noqa: F401
 
 
 # ------------------------- Utilities -------------------------


### PR DESCRIPTION
## Summary
- remove unused multiprocessing import
- consolidate tqdm imports
- keep a single Proposals import

## Testing
- `flake8 src/PTDAMH.py` *(fails: command not found)*
- `python -m py_compile src/PTDAMH.py`


------
https://chatgpt.com/codex/tasks/task_e_68adcc13eefc8331b2e1e752057f260c