### PR TITLE
Remove outdated parallel_tempering_swap code

### DIFF
--- a/docs/parallel_tempering_swap_archive.md
+++ b/docs/parallel_tempering_swap_archive.md
@@ -1,0 +1,119 @@
+# Archived `parallel_tempering_swap` implementations
+
+The repository previously contained experimental versions of `parallel_tempering_swap`. They are preserved here for reference.
+
+## Initial simple sweep
+
+```python
+@jax.jit
+def parallel_tempering_swap(key, temperatures: jnp.ndarray,
+                            thetas: jnp.ndarray, log_probs: jnp.ndarray):
+    """Single adjacent-swap sweep (even-odd could be added if desired).
+
+    Returns updated (thetas, log_probs), plus boolean decisions per edge.
+    """
+    C = temperatures.shape[0]
+    betas = 1.0 / temperatures
+    # Δβ * ΔlogL between neighbors (using current log_probs ~ log target)
+    dlog = (betas[1:] - betas[:-1]) * (log_probs[1:] - log_probs[:-1])
+
+    key, ukey = random.split(key)
+    u = jnp.log(random.uniform(ukey, shape=(C - 1,)))
+    do_swap = dlog >= u
+
+    def swap_edge(i, carry):
+        th, lp = carry
+        def yes():
+            th1 = th.at[i].set(th[i + 1])
+            th1 = th1.at[i + 1].set(th[i])
+            lp1 = lp.at[i].set(lp[i + 1])
+            lp1 = lp1.at[i + 1].set(lp[i])
+            return th1, lp1
+        return lax.cond(do_swap[i], yes, lambda: (th, lp))
+
+    thetas2, logp2 = lax.fori_loop(0, C - 1, swap_edge, (thetas, log_probs))
+    return key, thetas2, logp2, do_swap
+```
+
+## Vectorized sweep with parity selection
+
+```python
+def _apply_swaps_vec(arr, i, j, accept):
+    """
+    arr: (C, ...) values to swap
+    i,j: (K,) pair indices
+    accept: (K,) booleans
+    """
+    ai, aj = arr[i], arr[j]
+    acc = accept.astype(bool)
+    if arr.ndim == 1:
+        out = arr.at[i].set(jnp.where(acc, aj, ai))
+        out = out.at[j].set(jnp.where(acc, ai, aj))
+        return out
+    else:
+        # Expand mask to (K, 1, 1, ..., 1) to match ai/aj
+        acc_b = acc.reshape(acc.shape + (1,)*(ai.ndim - 1))
+        out = arr.at[i].set(jnp.where(acc_b, aj, ai))
+        out = out.at[j].set(jnp.where(acc_b, ai, aj))
+        return out
+
+@jax.jit
+def parallel_tempering_swap(key, temperatures, thetas, log_probs, *, return_debug=False):
+    """
+    One PT swap sweep (even or odd, chosen at random).
+    temperatures: (C,)  *absolute T* (T0=1 is cold).  β = 1/T is computed inside.
+    thetas:       (C,D)
+    log_probs:    (C,)  untempered log π(θ) (includes prior!), not scaled by T.
+    returns: key, thetas_new, log_probs_new, swap_decisions (C-1,) bool [, debug dict]
+    """
+    C = thetas.shape[0]
+    beta = 1.0 / jnp.asarray(temperatures)
+    n_edges = C - 1
+
+    # Build even/odd adjacent index sets; pad odd to same static length
+    i_even = jnp.arange(0, n_edges, 2, dtype=jnp.int32)   # Ke = ceil(n_edges/2)
+    i_odd  = jnp.arange(1, n_edges, 2, dtype=jnp.int32)   # Ko = floor(n_edges/2)
+    Ke = i_even.shape[0]
+    Ko = i_odd.shape[0]
+    pad = Ke - Ko
+    i_odd_padded = jnp.concatenate([i_odd, -jnp.ones((pad,), dtype=jnp.int32)], axis=0)
+    valid_even = jnp.ones((Ke,), dtype=bool)
+    valid_odd  = jnp.arange(Ke) < Ko
+
+    # RNG: advance key and get subkeys
+    key, k_par = random.split(key)
+    key, k_u   = random.split(key)
+    parity = random.bernoulli(k_par)  # False->even, True->odd
+
+    def pick_even():
+        return i_even, valid_even
+    def pick_odd():
+        return i_odd_padded, valid_odd
+
+    i_raw, valid = lax.cond(parity, pick_odd, pick_even)  # both (Ke,)
+    # Safe indices for padded slots (map invalid to 0; we’ll mask later)
+    i = jnp.where(valid, i_raw, jnp.zeros_like(i_raw))
+    j = i + 1
+    i = i.astype(jnp.int32)
+    j = j.astype(jnp.int32)
+
+    # Correct MH exponent for swaps: Δ = (β_i - β_j) * (lp_j - lp_i)
+    delta = (beta[i] - beta[j]) * (log_probs[j] - log_probs[i])     # (Ke,)
+    delta = jnp.where(valid, delta, -jnp.inf)                        # mask padded
+    ulog  = jnp.log(random.uniform(k_u, shape=delta.shape))
+    accept_sel = ulog < delta
+    accept_sel = accept_sel.astype(bool)                             # (Ke,)
+
+    # Apply swaps simultaneously on the selected (non-overlapping) pairs
+    thetas_new = _apply_swaps_vec(thetas,    i, j, accept_sel)
+    logp_new   = _apply_swaps_vec(log_probs, i, j, accept_sel)
+
+    # Raster of decisions over all edges (C-1,)
+    raster = jnp.zeros((n_edges,), dtype=bool).at[i].set(jnp.where(valid, accept_sel, False))
+
+    if return_debug:
+        dbg = {"delta": delta, "ulog": ulog, "pairs_i": i, "pairs_j": j,
+               "accept_sel": accept_sel, "parity": parity}
+        return key, thetas_new, logp_new, raster, dbg
+    return key, thetas_new, logp_new, raster
+```

--- a/src/PTDAMH.py
+++ b/src/PTDAMH.py
@@ -130,113 +130,6 @@ class StepInfo(NamedTuple):
 
 
 # ------------------------- Parallel tempering swap -------------------------
-# @jax.jit
-# def parallel_tempering_swap(key, temperatures: jnp.ndarray,
-#                             thetas: jnp.ndarray, log_probs: jnp.ndarray):
-#     """Single adjacent-swap sweep (even-odd could be added if desired).
-
-#     Returns updated (thetas, log_probs), plus boolean decisions per edge.
-#     """
-#     C = temperatures.shape[0]
-#     betas = 1.0 / temperatures
-#     # Δβ * ΔlogL between neighbors (using current log_probs ~ log target)
-#     dlog = (betas[1:] - betas[:-1]) * (log_probs[1:] - log_probs[:-1])
-
-#     key, ukey = random.split(key)
-#     u = jnp.log(random.uniform(ukey, shape=(C - 1,)))
-#     do_swap = dlog >= u
-
-#     def swap_edge(i, carry):
-#         th, lp = carry
-#         def yes():
-#             th1 = th.at[i].set(th[i + 1])
-#             th1 = th1.at[i + 1].set(th[i])
-#             lp1 = lp.at[i].set(lp[i + 1])
-#             lp1 = lp1.at[i + 1].set(lp[i])
-#             return th1, lp1
-#         return lax.cond(do_swap[i], yes, lambda: (th, lp))
-
-#     thetas2, logp2 = lax.fori_loop(0, C - 1, swap_edge, (thetas, log_probs))
-#     return key, thetas2, logp2, do_swap
-
-
-# def _apply_swaps_vec(arr, i, j, accept):
-#     """
-#     arr: (C, ...) values to swap
-#     i,j: (K,) pair indices
-#     accept: (K,) booleans
-#     """
-#     ai, aj = arr[i], arr[j]
-#     acc = accept.astype(bool)
-#     if arr.ndim == 1:
-#         out = arr.at[i].set(jnp.where(acc, aj, ai))
-#         out = out.at[j].set(jnp.where(acc, ai, aj))
-#         return out
-#     else:
-#         # Expand mask to (K, 1, 1, ..., 1) to match ai/aj
-#         acc_b = acc.reshape(acc.shape + (1,)*(ai.ndim - 1))
-#         out = arr.at[i].set(jnp.where(acc_b, aj, ai))
-#         out = out.at[j].set(jnp.where(acc_b, ai, aj))
-#         return out
-
-# @jax.jit
-# def parallel_tempering_swap(key, temperatures, thetas, log_probs, *, return_debug=False):
-#     """
-#     One PT swap sweep (even or odd, chosen at random).
-#     temperatures: (C,)  *absolute T* (T0=1 is cold).  β = 1/T is computed inside.
-#     thetas:       (C,D)
-#     log_probs:    (C,)  untempered log π(θ) (includes prior!), not scaled by T.
-#     returns: key, thetas_new, log_probs_new, swap_decisions (C-1,) bool [, debug dict]
-#     """
-#     C = thetas.shape[0]
-#     beta = 1.0 / jnp.asarray(temperatures)
-#     n_edges = C - 1
-
-#     # Build even/odd adjacent index sets; pad odd to same static length
-#     i_even = jnp.arange(0, n_edges, 2, dtype=jnp.int32)   # Ke = ceil(n_edges/2)
-#     i_odd  = jnp.arange(1, n_edges, 2, dtype=jnp.int32)   # Ko = floor(n_edges/2)
-#     Ke = i_even.shape[0]
-#     Ko = i_odd.shape[0]
-#     pad = Ke - Ko
-#     i_odd_padded = jnp.concatenate([i_odd, -jnp.ones((pad,), dtype=jnp.int32)], axis=0)
-#     valid_even = jnp.ones((Ke,), dtype=bool)
-#     valid_odd  = jnp.arange(Ke) < Ko
-
-#     # RNG: advance key and get subkeys
-#     key, k_par = random.split(key)
-#     key, k_u   = random.split(key)
-#     parity = random.bernoulli(k_par)  # False->even, True->odd
-
-#     def pick_even():
-#         return i_even, valid_even
-#     def pick_odd():
-#         return i_odd_padded, valid_odd
-
-#     i_raw, valid = lax.cond(parity, pick_odd, pick_even)  # both (Ke,)
-#     # Safe indices for padded slots (map invalid to 0; we’ll mask later)
-#     i = jnp.where(valid, i_raw, jnp.zeros_like(i_raw))
-#     j = i + 1
-#     i = i.astype(jnp.int32)
-#     j = j.astype(jnp.int32)
-
-#     # Correct MH exponent for swaps: Δ = (β_i - β_j) * (lp_j - lp_i)
-#     delta = (beta[i] - beta[j]) * (log_probs[j] - log_probs[i])     # (Ke,)
-#     delta = jnp.where(valid, delta, -jnp.inf)                        # mask padded
-#     ulog  = jnp.log(random.uniform(k_u, shape=delta.shape))
-#     accept_sel = ulog < delta 
-#     accept_sel = accept_sel.astype(bool)                                       # (Ke,)
-
-#     # Apply swaps simultaneously on the selected (non-overlapping) pairs
-#     thetas_new = _apply_swaps_vec(thetas,    i, j, accept_sel)
-#     logp_new   = _apply_swaps_vec(log_probs, i, j, accept_sel)
-
-#     # Raster of decisions over all edges (C-1,)
-#     raster = jnp.zeros((n_edges,), dtype=bool).at[i].set(jnp.where(valid, accept_sel, False))
-
-#     if return_debug:
-#         dbg = {"delta": delta, "ulog": ulog, "pairs_i": i, "pairs_j": j, "accept_sel": accept_sel, "parity": parity}
-#         return key, thetas_new, logp_new, raster, dbg
-#     return key, thetas_new, logp_new, raster
 
 
 
@@ -341,17 +234,6 @@ def _pt_swap_core_parity(key, temperatures, thetas, log_probs, parity: jnp.bool_
     raster = jnp.zeros((n_edges,), dtype=bool).at[i].set(jnp.where(valid, accept_sel, False))
     return key, thetas_new, logp_new, raster, i, j, accept_sel, delta, ulog
 
-# def parallel_tempering_swap(key, temperatures, thetas, log_probs, *, return_debug=False):
-#     key2, th2, lp2, raster, i, j, acc_sel, delta, ulog, parity = _pt_swap_core(
-#         key, temperatures, thetas, log_probs
-#     )
-#     if return_debug:
-#         dbg = {
-#             "pairs_i": i, "pairs_j": j, "accept_sel": acc_sel,
-#             "delta": delta, "ulog": ulog, "parity": parity
-#         }
-#         return key2, th2, lp2, raster, dbg
-#     return key2, th2, lp2, raster
 
 def parallel_tempering_swap(key, temperatures, thetas, log_probs, *,
                             return_debug=False, two_sweeps=True):
@@ -756,7 +638,6 @@ def run_epoch_device_fast(
         # lp_new = jnp.where(accept,          prop_lp,     lp)
 
         # PT swap (adjacent)
-        # _, th_sw, lp_sw, swap_dec = parallel_tempering_swap(kS, temperatures, th_new, lp_new)
         if do_swaps:
             _, th_sw, lp_sw, swap_dec = parallel_tempering_swap(kS, temperatures, th_new, lp_new)
         else:
@@ -1605,7 +1486,6 @@ def run_adaptive_pt_device_fast(
 #         lp_new = jnp.where(accept,        prop_lp,   lp)
 
 #         if do_swaps:
-#             _, th_sw, lp_sw, swap_dec = parallel_tempering_swap(kS, temperatures, th_new, lp_new)
 #         else:
 #             th_sw, lp_sw = th_new, lp_new
 #             swap_dec = jnp.zeros((C-1,), dtype=bool)
@@ -1651,7 +1531,6 @@ def run_adaptive_pt_device_fast(
 
 #         # PT swap (θ, lp, z) coherently
 #         if do_swaps:
-#             _, th_sw, lp_sw, raster, dbg = parallel_tempering_swap(kS, temperatures, th, lp, return_debug=True)
 #             i, j, acc_sel = dbg["pairs_i"], dbg["pairs_j"], dbg["accept_sel"]
 #             z_sw = _apply_swaps_vec(z, i, j, acc_sel)
 #         else:
@@ -1870,7 +1749,6 @@ def run_adaptive_pt_device_fast(
 #         new_nacc = state.n_accepted + accept.astype(jnp.int32)
 
 #         # PT adjacent swap
-#         key2, t_sw, lp_sw, swap_dec = parallel_tempering_swap(k_swap, state.temperatures, new_thetas, new_logps)
 #         n_swaps = state.n_swaps + swap_dec.astype(jnp.int32)
 #         n_swap_attempts = state.n_swap_attempts + jnp.ones_like(swap_dec, dtype=jnp.int32)
 

--- a/src/Proposals.py
+++ b/src/Proposals.py
@@ -571,10 +571,6 @@ def build_general_mixture_components_per_chain(
 #         new_log_probs = jnp.where(accept, proposal_log_probs, state.log_probs)
 #         new_n_acc = state.n_accepted + accept.astype(int)
 
-#         # Parallel tempering swap
-#         key, new_thetas, new_log_probs, swap_acc, swap_dec = parallel_tempering_swap(
-#             subkey_swap, state.temperatures, new_thetas, new_log_probs
-#         )
 
 #         new_state = PTState(
 #             thetas=new_thetas,


### PR DESCRIPTION
## Summary
- Strip commented `parallel_tempering_swap` implementations from core source
- Archive old swap implementations under docs for future reference
- Clean up stray commented swap calls

## Testing
- `ruff check src/PTDAMH.py src/Proposals.py` (fails: unused imports and other pre-existing style issues)


------
https://chatgpt.com/codex/tasks/task_e_68adcc73712483318b1651290def72af