### PR TITLE
Remove redundant imports in PTDAMH

### DIFF
--- a/src/PTDAMH.py
+++ b/src/PTDAMH.py
@@ -25,22 +25,14 @@ This module expects your `Proposals.py` next to it. It does **not** modify
 from __future__ import annotations
 
 from dataclasses import dataclass
-from multiprocessing.util import info
-from typing import Callable, NamedTuple, Tuple, Sequence
+from typing import NamedTuple
 
 import jax
 import jax.numpy as jnp
 from jax import lax, random, vmap
-import numpy as np
 from jax.scipy.linalg import solve_triangular
-from tqdm import tqdm
-from tqdm import trange
-
-
-import Proposals  # your file with proposal factories
-
+import numpy as np
 from tqdm import trange, tqdm
-
 
 import Proposals  # your file with proposal factories
 
@@ -366,11 +358,6 @@ class InfoAccumulator:
 # - Symmetric proposals -> no logq terms
 # - Chunked batched likelihood inside the scan
 
-from typing import Tuple
-import numpy as np
-import jax
-import jax.numpy as jnp
-from jax import random, lax, vmap
 
 # --- helpers ---
 


### PR DESCRIPTION
## Summary
- deduplicate tqdm and Proposals imports
- drop unused typing and multiprocessing imports

## Testing
- `python -m py_compile src/PTDAMH.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adceeb21e88331b99056bc68070b41