### PR TITLE
Expose ensemble runner functions in package init

### DIFF
--- a/src/ptdamh/__init__.py
+++ b/src/ptdamh/__init__.py
@@ -14,6 +14,12 @@ from .proposals import (
     build_general_mixture_components_per_chain,
 )
 
+from .ensemble_runner import (
+    run_epoch_device_fast_ensemble,
+    run_epoch_device_fast_M23_ensemble,
+    run_adaptive_pt_device_fast,
+)
+
 __all__ = [
     "_build_epoch_components",
     "_propose_fullcov",
@@ -22,5 +28,8 @@ __all__ = [
     "_propose_pcn",
     "_pcn_logq_delta",
     "build_general_mixture_components_per_chain",
+    "run_epoch_device_fast_ensemble",
+    "run_epoch_device_fast_M23_ensemble",
+    "run_adaptive_pt_device_fast",
 ]
 


### PR DESCRIPTION
## Summary
- Re-export ensemble runner helpers at top-level `ptdamh` package
- Update `__all__` for new functions to allow direct imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1abe765f4833196b2b6eca94b641f